### PR TITLE
Add `OutagesOverlay`

### DIFF
--- a/components/BarChart/BarChart.js
+++ b/components/BarChart/BarChart.js
@@ -1,0 +1,28 @@
+import Tippy from "@tippyjs/react";
+
+const Bar = () => {
+  return (
+    <Tippy
+      content={
+        <div className="text-center text-sm">
+          <p className="text-gray-200">July 19th</p>
+          <p>No outage</p>
+        </div>
+      }
+    >
+      <div className="h-8 flex-grow bg-green-500 rounded" />
+    </Tippy>
+  );
+};
+
+const BarChart = () => {
+  return (
+    <div className="flex space-x-1">
+      {[...Array(30)].map((e, index) => (
+        <Bar key={index} />
+      ))}
+    </div>
+  );
+};
+
+export default BarChart;

--- a/components/CurrentStatus/CurrentStatus.js
+++ b/components/CurrentStatus/CurrentStatus.js
@@ -48,10 +48,10 @@ const CurrentStatus = ({ status }) => {
       <div className="container text-center">
         {renderIcon()}
         <h1 className="mt-4 mb-3 c_h-heading c_h-heading--3xl sm:c_h-heading--4xl">
-          {status == "UP" ? "No known issues" : "We’re experiencing issues"}
+          {status == "up" ? "No known issues" : "We’re experiencing issues"}
         </h1>
         <p className="text-gray-700">
-          {status == "UP" ? (
+          {status == "up" ? (
             <>
               Don{"'"}t agree with this? Please{" "}
               <a href="mailto:contact@appsignal.com">let us know</a>.
@@ -72,7 +72,7 @@ const CurrentStatus = ({ status }) => {
 };
 
 CurrentStatus.propTypes = {
-  status: PropTypes.oneOf(["UP", "DOWN"]).isRequired,
+  status: PropTypes.oneOf(["up", "down"]).isRequired,
 };
 
 export default CurrentStatus;

--- a/components/CurrentStatus/CurrentStatus.js
+++ b/components/CurrentStatus/CurrentStatus.js
@@ -8,12 +8,12 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 const iconMapping = {
-  UP: {
+  up: {
     outerStyle: "bg-green-200",
     innerStyle: "bg-green-500",
     icon: faCheck,
   },
-  DOWN: {
+  down: {
     outerStyle: "bg-red-200",
     innerStyle: "bg-red-500",
     icon: faExclamationTriangle,

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -4,7 +4,7 @@ const Footer = () => {
   return (
     <footer className="mt-16 mb-12">
       <div className="container">
-        <p className="flex items-center justify-center text-sm text-gray-700">
+        <div className="flex items-center justify-center text-sm text-gray-700">
           <span>Get your own status page at</span>
           <a
             className="flex items-center ml-2"
@@ -19,7 +19,7 @@ const Footer = () => {
               width={86}
             />
           </a>
-        </p>
+        </div>
       </div>
     </footer>
   );

--- a/components/OutagesOverlay/Outage.js
+++ b/components/OutagesOverlay/Outage.js
@@ -1,0 +1,27 @@
+import PropTypes from "prop-types";
+import StatusIcon from "../StatusIcon/StatusIcon";
+
+const Outage = ({ region, from, till }) => {
+  return (
+    <div className="flex justify-between p-4">
+      <div className="w-1/2 flex items-center space-x-3">
+        <StatusIcon status="error" />
+        <p>
+          Down from <span className="font-semibold">{region}</span>
+        </p>
+      </div>
+      <p className="w-1/2 text-gray-700">
+        {from} <br />
+        {till}
+      </p>
+    </div>
+  );
+};
+
+Outage.propTypes = {
+  region: PropTypes.string.isRequired,
+  from: PropTypes.string.isRequired,
+  till: PropTypes.string.isRequired,
+};
+
+export default Outage;

--- a/components/OutagesOverlay/OutagesBox.js
+++ b/components/OutagesOverlay/OutagesBox.js
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types";
+
+import Outage from "./Outage";
+
+const OutagesBox = ({ outages }) => {
+  return (
+    <div className="bg-white shadow-sm rounded divide-y divide-gray-200">
+      {outages.map((outage, index) => (
+        <Outage
+          key={index}
+          status={outage.status}
+          region={outage.region}
+          from={outage.from}
+          till={outage.till}
+        />
+      ))}
+    </div>
+  );
+};
+
+OutagesBox.propTypes = {
+  outages: PropTypes.array.isRequired,
+};
+
+export default OutagesBox;

--- a/components/OutagesOverlay/OutagesList.js
+++ b/components/OutagesOverlay/OutagesList.js
@@ -1,0 +1,39 @@
+import PropTypes from "prop-types";
+
+import OutagesBox from "./OutagesBox";
+
+const getOutagesPerDay = (outages) => {
+  return outages.reduce((days, outage) => {
+    const date = outage.from.split("T")[0];
+
+    if (!days[date]) {
+      days[date] = [];
+    }
+
+    days[date].push(outage);
+    return days;
+  }, {});
+};
+
+const Outages = ({ outages }) => {
+  const outagesPerDay = getOutagesPerDay(outages);
+
+  return (
+    <ul className="space-y-6">
+      {Object.keys(outagesPerDay).map((day, index) => (
+        <li key={index}>
+          <h3 className="text-gray-700 mb-4">
+            {new Date(day).toLocaleDateString()}
+          </h3>
+          <OutagesBox outages={outagesPerDay[day]} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+Outages.propTypes = {
+  outages: PropTypes.array.isRequired,
+};
+
+export default Outages;

--- a/components/OutagesOverlay/OutagesOverlay.js
+++ b/components/OutagesOverlay/OutagesOverlay.js
@@ -1,0 +1,35 @@
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
+
+import Overlay from "../Overlay/Overlay";
+import OutagesList from "./OutagesList";
+
+const OutagesOverlay = ({ outages, open, handleClose }) => {
+  return (
+    <Overlay open={open}>
+      <div className="flex justify-end">
+        <div className="w-full max-w-2xl h-screen bg-gray-100">
+          <div className="flex justify-between items-center px-6 py-5 border-b border-gray-200">
+            <h2 className="c_h-heading">All outages of AppSignal Homepage</h2>
+            <button onClick={handleClose} className="focus:outline-none">
+              <FontAwesomeIcon icon={faTimes} />
+            </button>
+          </div>
+
+          <div className="p-6">
+            <OutagesList outages={outages} />
+          </div>
+        </div>
+      </div>
+    </Overlay>
+  );
+};
+
+OutagesOverlay.propTypes = {
+  outages: PropTypes.array.isRequired,
+  open: PropTypes.bool.isRequired,
+  handleClose: PropTypes.func.isRequired,
+};
+
+export default OutagesOverlay;

--- a/components/Overlay/Overlay.js
+++ b/components/Overlay/Overlay.js
@@ -1,0 +1,19 @@
+import PropTypes from "prop-types";
+import Portal from "../Portal/Portal";
+
+const Overlay = ({ children, open }) => {
+  if (!open) return null;
+
+  return (
+    <Portal>
+      <div className="fixed inset-0 bg-gray-900 bg-opacity-90">{children}</div>
+    </Portal>
+  );
+};
+
+Overlay.propTypes = {
+  children: PropTypes.object.isRequired,
+  open: PropTypes.bool.isRequired,
+};
+
+export default Overlay;

--- a/components/Portal/Portal.js
+++ b/components/Portal/Portal.js
@@ -1,0 +1,22 @@
+import PropTypes from "prop-types";
+import { useRef, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+const Portal = ({ children, selector = "#portal" }) => {
+  const ref = useRef(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    ref.current = document.querySelector(selector);
+    setMounted(true);
+  }, [selector]);
+
+  return mounted ? createPortal(children, ref.current) : null;
+};
+
+Portal.propTypes = {
+  children: PropTypes.object.isRequired,
+  selector: PropTypes.string,
+};
+
+export default Portal;

--- a/components/StatusIcon/StatusIcon.js
+++ b/components/StatusIcon/StatusIcon.js
@@ -1,0 +1,45 @@
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faCheck,
+  faExclamation,
+  faInfo,
+} from "@fortawesome/free-solid-svg-icons";
+
+const iconMapping = {
+  success: {
+    icon: faCheck,
+    style: "bg-green-500 text-white",
+  },
+  warning: {
+    icon: faExclamation,
+    style: "bg-orange-500 text-white",
+  },
+  error: {
+    icon: faExclamation,
+    style: "bg-red-500 text-white",
+  },
+  default: {
+    icon: faInfo,
+    style: "bg-gray-200 text-gray-700",
+  },
+};
+
+const StatusIcon = ({ status }) => {
+  const style = iconMapping[status].style;
+  const icon = iconMapping[status].icon;
+
+  return (
+    <span
+      className={`flex items-center justify-center h-4 w-4 rounded-full ${style}`}
+    >
+      <FontAwesomeIcon icon={icon} style={{ fontSize: "8px" }} fixedWidth />
+    </span>
+  );
+};
+
+StatusIcon.propTypes = {
+  status: PropTypes.string.isRequired,
+};
+
+export default StatusIcon;

--- a/components/StatusUpdates/StatusUpdate.js
+++ b/components/StatusUpdates/StatusUpdate.js
@@ -1,47 +1,13 @@
 import PropTypes from "prop-types";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faCheck,
-  faExclamation,
-  faInfo,
-} from "@fortawesome/free-solid-svg-icons";
 
-const iconMapping = {
-  success: {
-    icon: faCheck,
-    style: "bg-green-500 text-white",
-  },
-  warning: {
-    icon: faExclamation,
-    style: "bg-orange-500 text-white",
-  },
-  error: {
-    icon: faExclamation,
-    style: "bg-red-500 text-white",
-  },
-  default: {
-    icon: faInfo,
-    style: "bg-gray-200 text-gray-700",
-  },
-};
+import StatusIcon from "../StatusIcon/StatusIcon";
 
-const StatusUpdate = ({ type, title, description, time }) => {
-  const renderIcon = () => {
-    const style = iconMapping[type].style;
-    const icon = iconMapping[type].icon;
-
-    return (
-      <span
-        className={`flex items-center justify-center h-4 w-4 rounded-full ${style}`}
-      >
-        <FontAwesomeIcon icon={icon} style={{ fontSize: "8px" }} fixedWidth />
-      </span>
-    );
-  };
-
+const StatusUpdate = ({ status, title, description, time }) => {
   return (
     <div className="flex bg-white shadow-sm rounded py-5 px-6">
-      <div className="mr-4 my-0.5">{renderIcon()}</div>
+      <div className="mr-4 my-0.5">
+        <StatusIcon status={status} />
+      </div>
       <div className="">
         <h3 className="c_h-heading mb-1">{title}</h3>
         {description && <p className="text-gray-700">{description}</p>}
@@ -52,7 +18,7 @@ const StatusUpdate = ({ type, title, description, time }) => {
 };
 
 StatusUpdate.propTypes = {
-  type: PropTypes.string.isRequired,
+  status: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
   time: PropTypes.string.isRequired,

--- a/components/StatusUpdates/StatusUpdates.js
+++ b/components/StatusUpdates/StatusUpdates.js
@@ -26,7 +26,7 @@ const StatusUpdates = () => {
   return (
     <section className="mt-20 mb-16">
       <div className="container">
-        <a name="status-updates" id="status-updates">
+        <a name="status-updates" id="status-updates" className="no-underline">
           <h2 className="c_h-heading c_h-heading--2xl mb-8 text-center">
             Status updates
           </h2>

--- a/components/StatusUpdates/StatusUpdates.js
+++ b/components/StatusUpdates/StatusUpdates.js
@@ -3,19 +3,19 @@ import StatusUpdate from "./StatusUpdate";
 
 const statusUpdates = [
   {
-    type: "success",
+    status: "success",
     title: "All systems are back up!",
     description: "",
     time: "15th Aug 08:11 CET",
   },
   {
-    type: "error",
+    status: "error",
     title: "We’re experiencing some issues",
     description: "Here’s a message with some context.",
     time: "15th Aug 07:53 CET",
   },
   {
-    type: "warning",
+    status: "warning",
     title: "Planned maintainance on August 15th between 02:00pm and 03:00pm",
     description: "Here’s a message with some context.",
     time: "11th Aug 15:11 CET",
@@ -35,7 +35,7 @@ const StatusUpdates = () => {
           {statusUpdates.map((update, index) => (
             <StatusUpdate
               key={index}
-              type={update.type}
+              status={update.status}
               title={update.title}
               description={update.description}
               time={update.time}

--- a/components/UptimeMonitors/UptimeMonitor.js
+++ b/components/UptimeMonitors/UptimeMonitor.js
@@ -1,36 +1,58 @@
 import PropTypes from "prop-types";
-import Tippy from "@tippyjs/react";
+import { useState } from "react";
 
-const Bar = () => {
-  return (
-    <Tippy
-      content={
-        <div className="text-center text-sm">
-          <p className="text-gray-200">July 19th</p>
-          <p>No outage</p>
-        </div>
-      }
-    >
-      <div className="h-8 flex-grow bg-green-500 rounded" />
-    </Tippy>
-  );
-};
+import BarChart from "../BarChart/BarChart";
+import OutagesOverlay from "../OutagesOverlay/OutagesOverlay";
+
+const outages = [
+  {
+    status: "error",
+    region: "North America",
+    from: "2021-08-15T08:06:00.000+02:00",
+    till: "2021-08-15T08:11:00.000+02:00",
+  },
+  {
+    status: "error",
+    region: "South America",
+    from: "2021-08-15T07:58:00.000+02:00",
+    till: "2021-08-15T08:01:00.000+02:00",
+  },
+  {
+    status: "error",
+    region: "North America",
+    from: "2021-08-07T23:56:00.000+02:00",
+    till: "2021-08-08T00:02:00.000+02:00",
+  },
+];
 
 const UptimeMonitor = ({ uptimeMonitor }) => {
+  const [overlayOpen, setOverlayOpen] = useState(false);
+
   return (
-    <div className="px-6 py-5 space-y-3">
-      <div className="sm:flex justify-between">
-        <h2 className="c_h-heading">{uptimeMonitor.title}</h2>
-        <p className="mt-1 sm:mt-0 text-gray-700">
-          Monitoring from 4 locations
-        </p>
+    <>
+      <div className="px-6 py-5 space-y-3">
+        <div className="sm:flex justify-between">
+          <h2>
+            <button
+              className="c_h-heading focus:outline-none"
+              onClick={() => setOverlayOpen(true)}
+            >
+              {uptimeMonitor.title}
+            </button>
+          </h2>
+          <p className="mt-1 sm:mt-0 text-gray-700">
+            Monitoring from 4 locations
+          </p>
+        </div>
+        <BarChart />
       </div>
-      <div className="flex space-x-1">
-        {[...Array(30)].map((e, index) => (
-          <Bar key={index} />
-        ))}
-      </div>
-    </div>
+
+      <OutagesOverlay
+        open={overlayOpen}
+        handleClose={() => setOverlayOpen(false)}
+        outages={outages}
+      />
+    </>
   );
 };
 

--- a/components/UptimeMonitors/UptimeMonitors.js
+++ b/components/UptimeMonitors/UptimeMonitors.js
@@ -2,13 +2,24 @@ import PropTypes from "prop-types";
 import UptimeMonitor from "./UptimeMonitor";
 
 const UptimeMonitors = ({ uptimeMonitors }) => {
+  const renderUptimeMonitors = () => {
+    if (uptimeMonitors.length === 0) {
+      return (
+        <div className="max-w-lg mx-auto bg-white shadow-sm rounded px-6 py-5">
+          <p className="text-gray-700 italic">No uptime monitors added yet.</p>
+        </div>
+      );
+    }
+
+    return uptimeMonitors.map((m) => (
+      <UptimeMonitor key={m.url} uptimeMonitor={m} />
+    ));
+  };
   return (
     <section className="mt-16 mb-20">
       <div className="container">
         <div className="max-w-lg mx-auto bg-white shadow-sm rounded divide-y divide-gray-200">
-          {uptimeMonitors.map((m) => (
-            <UptimeMonitor key={m.url} uptimeMonitor={m} />
-          ))}
+          {renderUptimeMonitors()}
         </div>
       </div>
     </section>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,6 +12,7 @@ class MyDocument extends Document {
         <Head />
         <body className="min-h-screen bg-gray-100 text-gray-800">
           <Main />
+          <div id="portal" />
           <NextScript />
         </body>
       </Html>

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,13 +24,17 @@ const App = ({ statusPage }) => {
   );
 };
 
-export async function getServerSideProps({ req }) {
-  const { headers } = req;
+export async function getServerSideProps() {
+  /*const { headers } = req;
   const hostname = headers["cdn-host"] || "status.appsignal-status.online";
   const result = await fetch(
     `https://api.appsignal-status.online/status_pages/${Buffer.from(
       hostname
     ).toString("base64")}.json`
+  );*/
+
+  const result = await fetch(
+    "https://staging.lol/api/status_pages/c3RhdHVzLmFwcHNpZ25hbC1zdGF0dXMub25saW5l.json"
   );
 
   if (!result.ok) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,7 +15,7 @@ const App = ({ statusPage }) => {
       </Head>
       <Header />
       <main>
-        <CurrentStatus status={statusPage.status} />
+        <CurrentStatus status={statusPage.state} />
         <UptimeMonitors uptimeMonitors={statusPage.uptime_monitors} />
         <StatusUpdates statusUpdates={[]} />
       </main>


### PR DESCRIPTION
#### Changes
- Added overlay logic using React's `usePortal` hook, based on [example from NextJS](https://github.com/vercel/next.js/tree/canary/examples/with-portals/)
  - Added `Portal` component
  - Added `Overlay` component
- Added `OutagesOverlay` component
  - Opens when clicking the uptime monitor name
  - Outages are not part of the API yet, so I just hardcoded something that I thought makes sense
  - Outages are automatically grouped and displayed by day
- Some minor code cleanups and fixes that got in my way
  - Abstracted status icon into `StatusIcon` component

#### Not part of this PR
There also a few things that I haven't got around to do yet, but I didn't want to make this PR even bigger. I think we can do these things in separate PRs:
- Prevent the background from scrolling when overlay is open
- Close overlay when clicking on background or pressing "ESC"
- Properly format all dates and times
- Update `StatusIcon` to use new statuses ("investigating", "resolved", etc.)