### PR TITLE
Remove get in touch and render page title

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -1,39 +1,26 @@
 import Link from "next/link";
-import Image from "next/image";
+import PropTypes from "prop-types";
 
-const Header = () => {
+const Header = ({ title }) => {
   return (
     <header className="bg-white shadow-sm">
       <div className="container flex justify-between items-center py-3">
         <nav className="flex space-x-2 sm:space-x-4">
-          <a
-            className="flex items-center no-underline font-semibold"
-            href="https://appsignal.com/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <Image
-              src="/assets/appsignal-logo.svg"
-              alt="AppSignal Logo"
-              height="20"
-              width="108"
-            />
+          <a className="flex items-center no-underline font-semibold" href="/">
+            {title}
           </a>
           <div className="h-6 w-px bg-gray-200 rounded" />
           <Link href="/">
             <a className="no-underline text-gray-700">Status</a>
           </Link>
         </nav>
-
-        <a
-          href="mailto:contact@appsignal.com"
-          className="c-button c-button--gray c-button--xs sm:c-button--sm"
-        >
-          Get in touch
-        </a>
       </div>
     </header>
   );
+};
+
+Header.propTypes = {
+  title: PropTypes.string.isRequired,
 };
 
 export default Header;

--- a/components/Header/Header.test.js
+++ b/components/Header/Header.test.js
@@ -1,11 +1,16 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import Header from "./Header";
 
 describe("Header", () => {
   test("renders without errors", () => {
-    const { container } = render(<Header />);
+    const { container } = render(<Header title="Some title" />);
     expect(container).toMatchSnapshot();
+  });
+
+  test("renders the title", () => {
+    render(<Header title="Dunder Mifflin" />);
+    expect(screen.getByText("Dunder Mifflin")).toBeInTheDocument();
   });
 });

--- a/components/Header/__snapshots__/Header.test.js.snap
+++ b/components/Header/__snapshots__/Header.test.js.snap
@@ -13,32 +13,9 @@ exports[`Header renders without errors 1`] = `
       >
         <a
           class="flex items-center no-underline font-semibold"
-          href="https://appsignal.com/"
-          rel="noreferrer"
-          target="_blank"
+          href="/"
         >
-          <div
-            style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="box-sizing: border-box; display: block; max-width: 100%;"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTA4IiBoZWlnaHQ9IjIwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIvPg=="
-                style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-              />
-            </div>
-            <noscript />
-            <img
-              alt="AppSignal Logo"
-              data-nimg="true"
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            />
-          </div>
+          Some title
         </a>
         <div
           class="h-6 w-px bg-gray-200 rounded"
@@ -50,12 +27,6 @@ exports[`Header renders without errors 1`] = `
           Status
         </a>
       </nav>
-      <a
-        class="c-button c-button--gray c-button--xs sm:c-button--sm"
-        href="mailto:contact@appsignal.com"
-      >
-        Get in touch
-      </a>
     </div>
   </header>
 </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,7 +13,7 @@ const App = ({ statusPage }) => {
       <Head>
         <title>{statusPage.title} Status</title>
       </Head>
-      <Header />
+      <Header title={statusPage.title} />
       <main>
         <CurrentStatus state={statusPage.state} />
         <UptimeMonitors statusPage={statusPage} />


### PR DESCRIPTION
Make sure we render the Company name, otherwise people have no idea for
what company the status page is