### PR TITLE
Only render a downtime if it's below the specified threshold

### DIFF
--- a/components/UptimeDot/UptimeDot.js
+++ b/components/UptimeDot/UptimeDot.js
@@ -32,7 +32,7 @@ export const downtimeSummary = (timeserie, threshold) => {
   });
 };
 
-const UptimeDot = ({ timeserie, threshold = 5 }) => {
+const UptimeDot = ({ timeserie, threshold }) => {
   const uptimeDate = dayjs(timeserie.timestamp).format("MMM. Do");
 
   const stateColor = {
@@ -67,6 +67,10 @@ UptimeDot.propTypes = {
     values: PropTypes.object.isRequired,
   }),
   threshold: PropTypes.number,
+};
+
+UptimeDot.defaultProps = {
+  threshold: 5,
 };
 
 export default UptimeDot;

--- a/components/UptimeDot/UptimeDot.js
+++ b/components/UptimeDot/UptimeDot.js
@@ -18,7 +18,7 @@ export const downtimeSummary = (timeserie, threshold) => {
   if (state(timeserie, threshold) === "missing")
     return <p>We are missing datapoints for this day</p>;
   if (state(timeserie, threshold) === "up")
-    return <p>{`No downtimes under ${threshold} minutes`}</p>;
+    return <p>{`No downtimes over ${threshold} minutes`}</p>;
 
   return Object.keys(timeserie.values).map((region) => {
     const downtime = timeserie.values[region];

--- a/components/UptimeDot/UptimeDot.js
+++ b/components/UptimeDot/UptimeDot.js
@@ -6,21 +6,22 @@ dayjs.extend(advancedFormat);
 
 import { formatRegion } from "../../utils";
 
-const state = (timeserie) => {
+const state = (timeserie, threshold) => {
   if (timeserie.missingDataPoint) return "missing";
-  return Object.values(timeserie.values).reduce((a, b) => a + b) > 0
+  return Object.values(timeserie.values).reduce((a, b) => Math.max(a, b)) >
+    threshold
     ? "down"
     : "up";
 };
 
-export const downtimeSummary = (timeserie) => {
-  if (state(timeserie) === "missing")
+export const downtimeSummary = (timeserie, threshold) => {
+  if (state(timeserie, threshold) === "missing")
     return <p>We are missing datapoints for this day</p>;
   if (state(timeserie) === "up") return <p>No outage</p>;
 
   return Object.keys(timeserie.values).map((region) => {
     const downtime = timeserie.values[region];
-    if (downtime > 0) {
+    if (downtime > threshold) {
       return (
         <p key={region}>
           {formatRegion(region)} down for {downtime} minutes
@@ -45,13 +46,15 @@ const UptimeDot = ({ timeserie, threshold = 5 }) => {
       content={
         <div className="text-center text-sm">
           <p className="text-gray-200">{uptimeDate}</p>
-          <div>{downtimeSummary(timeserie)}</div>
+          <div>{downtimeSummary(timeserie, threshold)}</div>
         </div>
       }
     >
       <div
         data-testid="uptimeDot"
-        className={`h-8 flex-grow ${stateColor[state(timeserie)]} rounded`}
+        className={`h-8 flex-grow ${
+          stateColor[state(timeserie, threshold)]
+        } rounded`}
       />
     </Tippy>
   );

--- a/components/UptimeDot/UptimeDot.js
+++ b/components/UptimeDot/UptimeDot.js
@@ -30,7 +30,7 @@ export const downtimeSummary = (timeserie) => {
   });
 };
 
-const UptimeDot = ({ timeserie }) => {
+const UptimeDot = ({ timeserie, threshold = 5 }) => {
   const uptimeDate = dayjs(timeserie.timestamp).format("MMM. Do");
 
   const stateColor = {
@@ -62,6 +62,7 @@ UptimeDot.propTypes = {
     timestamp: PropTypes.string.isRequired,
     values: PropTypes.object.isRequired,
   }),
+  threshold: PropTypes.number,
 };
 
 export default UptimeDot;

--- a/components/UptimeDot/UptimeDot.js
+++ b/components/UptimeDot/UptimeDot.js
@@ -17,7 +17,8 @@ const state = (timeserie, threshold) => {
 export const downtimeSummary = (timeserie, threshold) => {
   if (state(timeserie, threshold) === "missing")
     return <p>We are missing datapoints for this day</p>;
-  if (state(timeserie) === "up") return <p>No outage</p>;
+  if (state(timeserie, threshold) === "up")
+    return <p>{`No downtimes under ${threshold} minutes`}</p>;
 
   return Object.keys(timeserie.values).map((region) => {
     const downtime = timeserie.values[region];

--- a/components/UptimeDot/UptimeDot.test.js
+++ b/components/UptimeDot/UptimeDot.test.js
@@ -38,14 +38,32 @@ describe("UptimeDot", () => {
     expect(dot.classList).toContain("bg-green-500");
   });
 
-  test("dot is red when down", () => {
+  test("dot is red when down and above threshold", () => {
     const { container } = build({ timeserie: down, threshold: 0 });
     const dot = container.querySelector("div");
     expect(dot.classList).toContain("bg-red-500");
   });
 
+  test("dot is green when down and under threshold", () => {
+    const { container } = build({ timeserie: down, threshold: 80 });
+    const dot = container.querySelector("div");
+    expect(dot.classList).toContain("bg-green-500");
+  });
+
   test("renders a tooltip when hovering", async () => {
     const { container } = build({ timeserie: up, threshold: 5 });
+    const dot = container.querySelector("div");
+
+    fireEvent.mouseEnter(dot);
+
+    expect(await screen.findByText("Aug. 6th")).toBeInTheDocument();
+    expect(
+      screen.getByText("No downtimes under 5 minutes")
+    ).toBeInTheDocument();
+  });
+
+  test("threshold defaults to 5 when undefined", async () => {
+    const { container } = build({ timeserie: up, threshold: undefined });
     const dot = container.querySelector("div");
 
     fireEvent.mouseEnter(dot);

--- a/components/UptimeDot/UptimeDot.test.js
+++ b/components/UptimeDot/UptimeDot.test.js
@@ -23,7 +23,7 @@ const down = {
 };
 
 const build = (props = {}) => {
-  return render(<UptimeDot timeserie={up} {...props} />);
+  return render(<UptimeDot timeserie={up} threshold={5} {...props} />);
 };
 
 describe("UptimeDot", () => {
@@ -39,25 +39,27 @@ describe("UptimeDot", () => {
   });
 
   test("dot is red when down", () => {
-    const { container } = build({ timeserie: down });
+    const { container } = build({ timeserie: down, threshold: 0 });
     const dot = container.querySelector("div");
     expect(dot.classList).toContain("bg-red-500");
   });
 
   test("renders a tooltip when hovering", async () => {
-    const { container } = build({ timeserie: up });
+    const { container } = build({ timeserie: up, threshold: 5 });
     const dot = container.querySelector("div");
 
     fireEvent.mouseEnter(dot);
 
     expect(await screen.findByText("Aug. 6th")).toBeInTheDocument();
-    expect(screen.getByText("No outage")).toBeInTheDocument();
+    expect(
+      screen.getByText("No downtimes under 5 minutes")
+    ).toBeInTheDocument();
   });
 });
 
 describe("#downtimeSummary", () => {
   test("returns downtime for different regions", () => {
-    render(downtimeSummary(down));
+    render(downtimeSummary(down, 5));
     expect(screen.getByText("Europe down for 60 minutes")).toBeInTheDocument();
     expect(
       screen.getByText("North America down for 60 minutes")
@@ -70,8 +72,10 @@ describe("#downtimeSummary", () => {
     ).toBeInTheDocument();
   });
 
-  test("returns 'no outage' if nothing was down", () => {
-    render(downtimeSummary(up));
-    expect(screen.getByText("No outage")).toBeInTheDocument();
+  test("returns 'no downtimes under N minutes' if nothing was down", () => {
+    render(downtimeSummary(up, 10));
+    expect(
+      screen.getByText("No downtimes under 10 minutes")
+    ).toBeInTheDocument();
   });
 });

--- a/components/UptimeDot/UptimeDot.test.js
+++ b/components/UptimeDot/UptimeDot.test.js
@@ -57,9 +57,7 @@ describe("UptimeDot", () => {
     fireEvent.mouseEnter(dot);
 
     expect(await screen.findByText("Aug. 6th")).toBeInTheDocument();
-    expect(
-      screen.getByText("No downtimes under 5 minutes")
-    ).toBeInTheDocument();
+    expect(screen.getByText("No downtimes over 5 minutes")).toBeInTheDocument();
   });
 
   test("threshold defaults to 5 when undefined", async () => {
@@ -69,9 +67,7 @@ describe("UptimeDot", () => {
     fireEvent.mouseEnter(dot);
 
     expect(await screen.findByText("Aug. 6th")).toBeInTheDocument();
-    expect(
-      screen.getByText("No downtimes under 5 minutes")
-    ).toBeInTheDocument();
+    expect(screen.getByText("No downtimes over 5 minutes")).toBeInTheDocument();
   });
 });
 
@@ -90,10 +86,10 @@ describe("#downtimeSummary", () => {
     ).toBeInTheDocument();
   });
 
-  test("returns 'no downtimes under N minutes' if nothing was down", () => {
+  test("returns 'No downtimes over N minutes' if nothing was down", () => {
     render(downtimeSummary(up, 10));
     expect(
-      screen.getByText("No downtimes under 10 minutes")
+      screen.getByText("No downtimes over 10 minutes")
     ).toBeInTheDocument();
   });
 });

--- a/components/UptimeDots/UptimeDots.js
+++ b/components/UptimeDots/UptimeDots.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import UptimeDot from "../UptimeDot";
 import { fillMissingDataPoints, timeseriesByDay } from "../../utils";
 
-const UptimeDots = ({ timeseries, regions }) => {
+const UptimeDots = ({ timeseries, regions, threshold }) => {
   const filledTimeseries = fillMissingDataPoints(
     timeseriesByDay(timeseries, regions).slice(-30, timeseries.length),
     30
@@ -12,7 +12,11 @@ const UptimeDots = ({ timeseries, regions }) => {
   return (
     <div className="flex space-x-1">
       {filledTimeseries.slice(-30, filledTimeseries.length).map((timeserie) => (
-        <UptimeDot key={timeserie.timestamp} timeserie={timeserie} />
+        <UptimeDot
+          key={timeserie.timestamp}
+          timeserie={timeserie}
+          threshold={threshold}
+        />
       ))}
     </div>
   );
@@ -21,6 +25,7 @@ const UptimeDots = ({ timeseries, regions }) => {
 UptimeDots.propTypes = {
   timeseries: PropTypes.array.isRequired,
   regions: PropTypes.array.isRequired,
+  threshold: PropTypes.number,
 };
 
 export default UptimeDots;

--- a/components/UptimeDots/UptimeDots.test.js
+++ b/components/UptimeDots/UptimeDots.test.js
@@ -10,6 +10,7 @@ const build = (props = {}) => {
     <UptimeDots
       timeseries={homepageMock.timeseries}
       regions={statusPageMock.uptime_monitors[0].regions}
+      threshold={statusPageMock.threshold}
       {...props}
     />
   );

--- a/components/UptimeDots/__snapshots__/UptimeDots.test.js.snap
+++ b/components/UptimeDots/__snapshots__/UptimeDots.test.js.snap
@@ -10,7 +10,7 @@ exports[`UptimeDots renders without errors 1`] = `
       data-testid="uptimeDot"
     />
     <div
-      class="h-8 flex-grow bg-green-500 rounded"
+      class="h-8 flex-grow bg-gray-200 rounded"
       data-testid="uptimeDot"
     />
     <div

--- a/components/UptimeMonitor/UptimeMonitor.js
+++ b/components/UptimeMonitor/UptimeMonitor.js
@@ -24,7 +24,7 @@ export const UptimeMonitorLoading = () => {
   );
 };
 
-const UptimeMonitor = ({ uptimeMonitor }) => {
+const UptimeMonitor = ({ uptimeMonitor, threshold }) => {
   const [overlayOpen, setOverlayOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [monitor, setMonitor] = React.useState([]);
@@ -67,6 +67,7 @@ const UptimeMonitor = ({ uptimeMonitor }) => {
           <UptimeDots
             timeseries={monitor.timeseries}
             regions={uptimeMonitor.regions}
+            threshold={threshold}
           />
         )}
       </div>
@@ -86,6 +87,7 @@ const UptimeMonitor = ({ uptimeMonitor }) => {
 
 UptimeMonitor.propTypes = {
   uptimeMonitor: PropTypes.object.isRequired,
+  threshold: PropTypes.number,
 };
 
 export default UptimeMonitor;

--- a/components/UptimeMonitor/UptimeMonitor.test.js
+++ b/components/UptimeMonitor/UptimeMonitor.test.js
@@ -7,6 +7,7 @@ const build = (props = {}) => {
   return render(
     <UptimeMonitor
       uptimeMonitor={statusPageMock.uptime_monitors[0]}
+      threshold={statusPageMock.threshold}
       {...props}
     />
   );

--- a/components/UptimeMonitors/UptimeMonitors.js
+++ b/components/UptimeMonitors/UptimeMonitors.js
@@ -12,7 +12,11 @@ const UptimeMonitors = ({ statusPage }) => {
     }
 
     return statusPage.uptime_monitors.map((monitor) => (
-      <UptimeMonitor key={monitor.url} uptimeMonitor={monitor} />
+      <UptimeMonitor
+        key={monitor.url}
+        uptimeMonitor={monitor}
+        threshold={statusPage.threshold}
+      />
     ));
   };
   return (
@@ -29,6 +33,7 @@ const UptimeMonitors = ({ statusPage }) => {
 UptimeMonitors.propTypes = {
   statusPage: PropTypes.shape({
     uptime_monitors: PropTypes.array.isRequired,
+    threshold: PropTypes.number,
   }).isRequired,
 };
 

--- a/components/UptimeMonitors/UptimeMonitors.js
+++ b/components/UptimeMonitors/UptimeMonitors.js
@@ -33,7 +33,7 @@ const UptimeMonitors = ({ statusPage }) => {
 UptimeMonitors.propTypes = {
   statusPage: PropTypes.shape({
     uptime_monitors: PropTypes.array.isRequired,
-    threshold: PropTypes.number,
+    threshold: PropTypes.number.isRequired,
   }).isRequired,
 };
 

--- a/mocks/status_pages/appsignal.json
+++ b/mocks/status_pages/appsignal.json
@@ -4,6 +4,7 @@
   "title": "AppSignal",
   "description": "The AppSignal status page.. status page",
   "state": "up",
+  "threshold": 0,
   "updates": [
     {
       "id": "update-one",


### PR DESCRIPTION
We should only render a red bar with a down summary if the time it was down is above the threshold specified by the user