### PR TITLE
Replace defaultProps with default parameters

### DIFF
--- a/components/UptimeDot/UptimeDot.js
+++ b/components/UptimeDot/UptimeDot.js
@@ -32,7 +32,7 @@ export const downtimeSummary = (timeserie, threshold) => {
   });
 };
 
-const UptimeDot = ({ timeserie, threshold }) => {
+const UptimeDot = ({ timeserie, threshold = 5 }) => {
   const uptimeDate = dayjs(timeserie.timestamp).format("MMM. Do");
 
   const stateColor = {
@@ -67,10 +67,6 @@ UptimeDot.propTypes = {
     values: PropTypes.object.isRequired,
   }),
   threshold: PropTypes.number,
-};
-
-UptimeDot.defaultProps = {
-  threshold: 5,
 };
 
 export default UptimeDot;

--- a/components/UptimeMonitors/UptimeMonitors.js
+++ b/components/UptimeMonitors/UptimeMonitors.js
@@ -15,7 +15,7 @@ const UptimeMonitors = ({ statusPage }) => {
       <UptimeMonitor
         key={monitor.url}
         uptimeMonitor={monitor}
-        threshold={statusPage.threshold}
+        threshold={statusPage.threshold || undefined}
       />
     ));
   };
@@ -33,7 +33,7 @@ const UptimeMonitors = ({ statusPage }) => {
 UptimeMonitors.propTypes = {
   statusPage: PropTypes.shape({
     uptime_monitors: PropTypes.array.isRequired,
-    threshold: PropTypes.number.isRequired,
+    threshold: PropTypes.number,
   }).isRequired,
 };
 


### PR DESCRIPTION
PropTypes `defaultProps` are being deprecated (see facebook/react#16210).
We should instead use default parameters.

Also, if threshold is falsy, passes it down as `undefined`, fixing a bug where `null` was being used in the UI.