### PR TITLE
Fix null threshold

### DIFF
--- a/components/UptimeDot/UptimeDot.js
+++ b/components/UptimeDot/UptimeDot.js
@@ -6,6 +6,7 @@ dayjs.extend(advancedFormat);
 
 import { formatRegion } from "../../utils";
 
+const DEFAULT_THRESHOLD = 5;
 const state = (timeserie, threshold) => {
   if (timeserie.missingDataPoint) return "missing";
   return Object.values(timeserie.values).reduce((a, b) => Math.max(a, b)) >
@@ -15,6 +16,7 @@ const state = (timeserie, threshold) => {
 };
 
 export const downtimeSummary = (timeserie, threshold) => {
+  if (threshold === null) threshold = DEFAULT_THRESHOLD;
   if (state(timeserie, threshold) === "missing")
     return <p>We are missing datapoints for this day</p>;
   if (state(timeserie, threshold) === "up")
@@ -70,7 +72,7 @@ UptimeDot.propTypes = {
 };
 
 UptimeDot.defaultProps = {
-  threshold: 5,
+  threshold: DEFAULT_THRESHOLD,
 };
 
 export default UptimeDot;

--- a/components/UptimeDot/UptimeDot.test.js
+++ b/components/UptimeDot/UptimeDot.test.js
@@ -69,6 +69,16 @@ describe("UptimeDot", () => {
     expect(await screen.findByText("Aug. 6th")).toBeInTheDocument();
     expect(screen.getByText("No downtimes over 5 minutes")).toBeInTheDocument();
   });
+
+  test("threshold defaults to 5 when null", async () => {
+    const { container } = build({ timeserie: up, threshold: null });
+    const dot = container.querySelector("div");
+
+    fireEvent.mouseEnter(dot);
+
+    expect(await screen.findByText("Aug. 6th")).toBeInTheDocument();
+    expect(screen.getByText("No downtimes over 5 minutes")).toBeInTheDocument();
+  });
 });
 
 describe("#downtimeSummary", () => {


### PR DESCRIPTION
When we get `null` back from the API as a threshold value we show this
as: "No downtime for null minutes". This makes sure that we can
gracefully handle the `null` value