### PR TITLE
Only mark a day as missing if there are less than the requested regions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 .env
+.envrc
 
 # vercel
 .vercel

--- a/components/Outages/__snapshots__/Outages.test.js.snap
+++ b/components/Outages/__snapshots__/Outages.test.js.snap
@@ -47,13 +47,13 @@ exports[`Outages renders without errors 1`] = `
                 class="font-semibold"
               >
                  
-                South America
+                Europe
                  
               </span>
               for 
-              1
+              5
                
-              minute
+              minutes
             </p>
           </div>
         </div>
@@ -94,13 +94,13 @@ exports[`Outages renders without errors 1`] = `
                 class="font-semibold"
               >
                  
-                Europe
+                South America
                  
               </span>
               for 
-              5
+              1
                
-              minutes
+              minute
             </p>
           </div>
         </div>
@@ -364,6 +364,53 @@ exports[`Outages renders without errors 1`] = `
                 class="font-semibold"
               >
                  
+                Europe
+                 
+              </span>
+              for 
+              6
+               
+              minutes
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="bg-white shadow-sm rounded divide-y divide-gray-200 my-1"
+        data-testid="outage"
+      >
+        <div
+          class="flex justify-between p-4"
+        >
+          <div
+            class="w-full flex items-center space-x-3"
+          >
+            <span
+              class="flex items-center justify-center h-4 w-4 rounded-full bg-orange-500 text-white"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-exclamation fa-fw "
+                data-icon="exclamation"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="font-size: 8px;"
+                viewBox="0 0 192 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <p>
+              Down from
+              <span
+                class="font-semibold"
+              >
+                 
                 South America
                  
               </span>
@@ -418,53 +465,6 @@ exports[`Outages renders without errors 1`] = `
               1
                
               minute
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="bg-white shadow-sm rounded divide-y divide-gray-200 my-1"
-        data-testid="outage"
-      >
-        <div
-          class="flex justify-between p-4"
-        >
-          <div
-            class="w-full flex items-center space-x-3"
-          >
-            <span
-              class="flex items-center justify-center h-4 w-4 rounded-full bg-orange-500 text-white"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
-                data-icon="exclamation"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
-                  fill="currentColor"
-                />
-              </svg>
-            </span>
-            <p>
-              Down from
-              <span
-                class="font-semibold"
-              >
-                 
-                Europe
-                 
-              </span>
-              for 
-              6
-               
-              minutes
             </p>
           </div>
         </div>
@@ -782,11 +782,11 @@ exports[`Outages renders without errors 1`] = `
                 class="font-semibold"
               >
                  
-                Asia Pacific
+                Europe
                  
               </span>
               for 
-              20
+              5
                
               minutes
             </p>
@@ -829,11 +829,11 @@ exports[`Outages renders without errors 1`] = `
                 class="font-semibold"
               >
                  
-                Europe
+                Asia Pacific
                  
               </span>
               for 
-              5
+              20
                
               minutes
             </p>

--- a/utils/index.js
+++ b/utils/index.js
@@ -30,14 +30,18 @@ export const timeseriesByDay = (timeseries, expectedRegions) => {
       currentGroup.missingDataPoint = true;
       currentGroup.values = {};
     } else {
-      if (!currentGroup.missingDataPoint)
-        currentGroup.missingDataPoint =
-          Object.keys(timeserie.values).length !== expectedRegions.length;
+      for (const region of expectedRegions) {
+        let value = timeserie.values[region];
 
-      Object.keys(timeserie.values).map((region) => {
-        if (!currentGroup.values[region]) currentGroup.values[region] = 0;
-        currentGroup.values[region] += timeserie.values[region];
-      });
+        if (!currentGroup.values[region]) {
+          currentGroup.values[region] = 0;
+        }
+        if (!isNaN(value)) {
+          currentGroup.values[region] += value;
+        } else {
+          currentGroup.missingDataPoint = true;
+        }
+      }
     }
 
     return group;

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -99,6 +99,56 @@ describe("#timeseriesByDay", () => {
 
     expect(byDay[0].missingDataPoint).toBeTruthy();
   });
+
+  test("it does not mark a day as missing if monitor regions is less than returned regions", () => {
+    const groupedTimeseries = timeseriesByDay(homepageMock.timeseries, [
+      "europe",
+      "asia-pacific",
+    ]).slice(0, 5);
+
+    expect(groupedTimeseries).toEqual([
+      {
+        missingDataPoint: false,
+        timestamp: "2021-07-26T00:00:00Z",
+        values: {
+          "asia-pacific": 20,
+          europe: 5,
+        },
+      },
+      {
+        missingDataPoint: false,
+        timestamp: "2021-07-27T00:00:00Z",
+        values: {
+          "asia-pacific": 0,
+          europe: 0,
+        },
+      },
+      {
+        missingDataPoint: false,
+        timestamp: "2021-07-28T00:00:00Z",
+        values: {
+          "asia-pacific": 0,
+          europe: 0,
+        },
+      },
+      {
+        missingDataPoint: false,
+        timestamp: "2021-07-29T00:00:00Z",
+        values: {
+          "asia-pacific": 0,
+          europe: 0,
+        },
+      },
+      {
+        missingDataPoint: false,
+        timestamp: "2021-07-30T00:00:00Z",
+        values: {
+          "asia-pacific": 0,
+          europe: 0,
+        },
+      },
+    ]);
+  });
 });
 
 describe("#fillMissingDataPoints", () => {


### PR DESCRIPTION
Before this commit, we would mark any day with an amount of regions not equal to the monitor as missing.

However the API can return 4 regions, while the monitor has 2 regions. We would mark this as missing days.

This commit fixes that issue. We only consider a day as missing, if the amount of regions is less than the monitor.