### PR TITLE
Update Nodejs 24 and bump Font Awesome to latest

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-nodejs 22.20.0
+nodejs 24.13.0
+yarn 1.22.22

--- a/components/CurrentStatus/CurrentStatus.test.js
+++ b/components/CurrentStatus/CurrentStatus.test.js
@@ -38,7 +38,7 @@ describe("CurrentStatus", () => {
     });
 
     expect(screen.getByRole("img", { hidden: true }).classList).toContain(
-      "fa-exclamation-triangle"
+      "fa-triangle-exclamation"
     );
 
     expect(

--- a/components/Outages/__snapshots__/Outages.test.js.snap
+++ b/components/Outages/__snapshots__/Outages.test.js.snap
@@ -26,17 +26,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -73,17 +71,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -127,17 +123,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -181,17 +175,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -235,17 +227,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -289,17 +279,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -343,17 +331,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -390,17 +376,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -437,17 +421,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -491,17 +473,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -545,17 +525,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -599,17 +577,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -653,17 +629,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -707,17 +681,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -761,17 +733,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -808,17 +778,15 @@ exports[`Outages renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>

--- a/components/StatusIcon/__snapshots__/StatusIcon.test.js.snap
+++ b/components/StatusIcon/__snapshots__/StatusIcon.test.js.snap
@@ -7,17 +7,15 @@ exports[`StatusIcon different states identified 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-exclamation fa-fw "
+      class="svg-inline--fa fa-exclamation fa-fw"
       data-icon="exclamation"
       data-prefix="fas"
-      focusable="false"
       role="img"
       style="font-size: 8px;"
-      viewBox="0 0 192 512"
-      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 128 512"
     >
       <path
-        d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+        d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
         fill="currentColor"
       />
     </svg>
@@ -32,17 +30,15 @@ exports[`StatusIcon different states investigating 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-exclamation fa-fw "
+      class="svg-inline--fa fa-exclamation fa-fw"
       data-icon="exclamation"
       data-prefix="fas"
-      focusable="false"
       role="img"
       style="font-size: 8px;"
-      viewBox="0 0 192 512"
-      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 128 512"
     >
       <path
-        d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+        d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
         fill="currentColor"
       />
     </svg>
@@ -57,17 +53,15 @@ exports[`StatusIcon different states recovering 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-exclamation fa-fw "
+      class="svg-inline--fa fa-exclamation fa-fw"
       data-icon="exclamation"
       data-prefix="fas"
-      focusable="false"
       role="img"
       style="font-size: 8px;"
-      viewBox="0 0 192 512"
-      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 128 512"
     >
       <path
-        d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+        d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
         fill="currentColor"
       />
     </svg>
@@ -82,17 +76,15 @@ exports[`StatusIcon different states resolved 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-check fa-fw "
+      class="svg-inline--fa fa-check fa-fw"
       data-icon="check"
       data-prefix="fas"
-      focusable="false"
       role="img"
       style="font-size: 8px;"
-      viewBox="0 0 512 512"
-      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 448 512"
     >
       <path
-        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+        d="M434.8 70.1c14.3 10.4 17.5 30.4 7.1 44.7l-256 352c-5.5 7.6-14 12.3-23.4 13.1s-18.5-2.7-25.1-9.3l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l101.5 101.5 234-321.7c10.4-14.3 30.4-17.5 44.7-7.1z"
         fill="currentColor"
       />
     </svg>
@@ -107,17 +99,15 @@ exports[`StatusIcon it renders without problems 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-check fa-fw "
+      class="svg-inline--fa fa-check fa-fw"
       data-icon="check"
       data-prefix="fas"
-      focusable="false"
       role="img"
       style="font-size: 8px;"
-      viewBox="0 0 512 512"
-      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 448 512"
     >
       <path
-        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+        d="M434.8 70.1c14.3 10.4 17.5 30.4 7.1 44.7l-256 352c-5.5 7.6-14 12.3-23.4 13.1s-18.5-2.7-25.1-9.3l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l101.5 101.5 234-321.7c10.4-14.3 30.4-17.5 44.7-7.1z"
         fill="currentColor"
       />
     </svg>

--- a/components/StatusUpdate/__snapshots__/StatusUpdate.test.js.snap
+++ b/components/StatusUpdate/__snapshots__/StatusUpdate.test.js.snap
@@ -14,17 +14,15 @@ exports[`StatusUpdate renders without errors 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-exclamation fa-fw "
+          class="svg-inline--fa fa-exclamation fa-fw"
           data-icon="exclamation"
           data-prefix="fas"
-          focusable="false"
           role="img"
           style="font-size: 8px;"
-          viewBox="0 0 192 512"
-          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 128 512"
         >
           <path
-            d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+            d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
             fill="currentColor"
           />
         </svg>

--- a/components/StatusUpdates/__snapshots__/StatusUpdates.test.js.snap
+++ b/components/StatusUpdates/__snapshots__/StatusUpdates.test.js.snap
@@ -34,17 +34,15 @@ exports[`StatusUpdates it renders without errors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>
@@ -87,17 +85,15 @@ Everything should be working fine soon. We are working on it. Please check back 
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-check fa-fw "
+                class="svg-inline--fa fa-check fa-fw"
                 data-icon="check"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 448 512"
               >
                 <path
-                  d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                  d="M434.8 70.1c14.3 10.4 17.5 30.4 7.1 44.7l-256 352c-5.5 7.6-14 12.3-23.4 13.1s-18.5-2.7-25.1-9.3l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l101.5 101.5 234-321.7c10.4-14.3 30.4-17.5 44.7-7.1z"
                   fill="currentColor"
                 />
               </svg>
@@ -130,17 +126,15 @@ Everything should be working fine soon. We are working on it. Please check back 
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-exclamation fa-fw "
+                class="svg-inline--fa fa-exclamation fa-fw"
                 data-icon="exclamation"
                 data-prefix="fas"
-                focusable="false"
                 role="img"
                 style="font-size: 8px;"
-                viewBox="0 0 192 512"
-                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 128 512"
               >
                 <path
-                  d="M176 432c0 44.112-35.888 80-80 80s-80-35.888-80-80 35.888-80 80-80 80 35.888 80 80zM25.26 25.199l13.6 272C39.499 309.972 50.041 320 62.83 320h66.34c12.789 0 23.331-10.028 23.97-22.801l13.6-272C167.425 11.49 156.496 0 142.77 0H49.23C35.504 0 24.575 11.49 25.26 25.199z"
+                  d="M64 432c22.1 0 40 17.9 40 40s-17.9 40-40 40-40-17.9-40-40c0-22.1 17.9-40 40-40zM64 0c26.5 0 48 21.5 48 48 0 .6 0 1.1 0 1.7l-16 304c-.9 17-15 30.3-32 30.3S33 370.7 32 353.7L16 49.7c0-.6 0-1.1 0-1.7 0-26.5 21.5-48 48-48z"
                   fill="currentColor"
                 />
               </svg>

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "format:check": "prettier --check './**/*.{js,jsx,ts,tsx,css,md,mdx,json}'"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.36",
-    "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@fortawesome/react-fontawesome": "^0.1.15",
+    "@fortawesome/fontawesome-svg-core": "^7.2.0",
+    "@fortawesome/free-solid-svg-icons": "^7.2.0",
+    "@fortawesome/react-fontawesome": "^3.2.0",
     "@tailwindcss/typography": "^0.5.9",
     "@tippyjs/react": "^4.2.5",
     "autoprefixer": "^10.4.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,36 +718,29 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@fortawesome/fontawesome-common-types@^0.2.36":
-  version "0.2.36"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
-  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+"@fortawesome/fontawesome-common-types@7.2.0":
+  version "7.2.0"
+  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz#ae54831ab5974bc1a64e8b07410f2da2b4abf87f"
+  integrity sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==
 
-"@fortawesome/fontawesome-common-types@^0.3.0":
-  version "0.3.0"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz#949995a05c0d8801be7e0a594f775f1dbaa0d893"
-  integrity sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==
-
-"@fortawesome/fontawesome-svg-core@^1.2.36":
-  version "1.3.0"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz#343fac91fa87daa630d26420bfedfba560f85885"
-  integrity sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==
+"@fortawesome/fontawesome-svg-core@^7.2.0":
+  version "7.2.0"
+  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz#813550a5e8946a798e170d3f7331a685f8f8a550"
+  integrity sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.3.0"
+    "@fortawesome/fontawesome-common-types" "7.2.0"
 
-"@fortawesome/free-solid-svg-icons@^5.15.4":
-  version "5.15.4"
-  resolved "https://npm.fontawesome.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
-  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+"@fortawesome/free-solid-svg-icons@^7.2.0":
+  version "7.2.0"
+  resolved "https://npm.fontawesome.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz#9c761f7ab393e281f750c54d9ed1ebbcd4d581fa"
+  integrity sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.36"
+    "@fortawesome/fontawesome-common-types" "7.2.0"
 
-"@fortawesome/react-fontawesome@^0.1.15":
-  version "0.1.19"
-  resolved "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz#2b36917578596f31934e71f92b7cf9c425fd06e4"
-  integrity sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==
-  dependencies:
-    prop-types "^15.8.1"
+"@fortawesome/react-fontawesome@^3.2.0":
+  version "3.2.0"
+  resolved "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/react-fontawesome-3.2.0.tgz#e30278eac8a0d1746e5dd6835faef91ad87eabf2"
+  integrity sha512-E9Gu1hqd6JussVO26EC4WqRZssXMnQr2ol7ZNWkkFOH8jZUaxDJ9Z9WF9wIVkC+kJGXUdY3tlffpDwEKfgQrQw==
 
 "@fullhuman/postcss-purgecss@^4.0.3":
   version "4.1.3"


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-status/issues/146

Updates Node.js to latest version.
Also updates  all `@fortawesome`  packages to latest to solve the deprecated `defaultProps` warnings.