### PR TITLE
Fix uptime percentage for latest completed day

### DIFF
--- a/components/UptimeMonitor/UptimeMonitor.js
+++ b/components/UptimeMonitor/UptimeMonitor.js
@@ -37,14 +37,15 @@ export const UptimeMonitorLoading = () => {
 
 export const calculateUptime = (timeseries, regions) => {
   const timeseriesByDay = groupTimeseriesByDay(timeseries, regions);
-  const latestDay = timeseriesByDay[timeseriesByDay.length - 1];
-  const completedTimeseriesByDay =
-    latestDay && dayjs(latestDay.timestamp).utc().isSame(dayjs().utc(), "day")
-      ? timeseriesByDay.slice(0, -1)
-      : timeseriesByDay;
-  const timeSeriesLast30Days = completedTimeseriesByDay
+  const now = dayjs().utc();
+  const timeSeriesLast30Days = timeseriesByDay
     .slice(-30)
-    .filter((item) => item.missingDataPoint === false);
+    .filter((item) => item.missingDataPoint === false)
+    .filter((item) => {
+      // Ignore a just-started current day until some uptime has actually elapsed.
+      return !dayjs(item.timestamp).utc().isSame(now, "day") ||
+        now.diff(dayjs(item.timestamp).utc(), "minute") > 0;
+    });
   const minutesPerDay = 1440.0;
 
   const downtimePerRegion = [];
@@ -57,12 +58,20 @@ export const calculateUptime = (timeseries, regions) => {
     const downtimeInMinutes = timeSeriesLast30Days.reduce((acc, item) => {
       return acc + item.values[region];
     }, 0);
+    const totalMeasuredMinutes = timeSeriesLast30Days.reduce((acc, item) => {
+      const timestamp = dayjs(item.timestamp).utc();
+
+      if (timestamp.isSame(now, "day")) {
+        return acc + now.diff(timestamp, "minute");
+      }
+
+      return acc + minutesPerDay;
+    }, 0);
 
     const uptimePercentage =
       100 -
       roundDecimal(
-        (100.0 / (minutesPerDay * timeSeriesLast30Days.length)) *
-          downtimeInMinutes
+        (100.0 / totalMeasuredMinutes) * downtimeInMinutes
       );
 
     downtimePerRegion.push({

--- a/components/UptimeMonitor/UptimeMonitor.js
+++ b/components/UptimeMonitor/UptimeMonitor.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import fetch from "cross-fetch";
 import Tippy from "@tippyjs/react";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 
 import OutagesOverlay from "../OutagesOverlay/OutagesOverlay";
 import UptimeDots from "../UptimeDots/UptimeDots";
@@ -10,6 +12,8 @@ import {
   timeseriesByDay as groupTimeseriesByDay,
   roundDecimal,
 } from "../../utils";
+
+dayjs.extend(utc);
 
 export const LoadingDot = () => {
   return (
@@ -33,8 +37,13 @@ export const UptimeMonitorLoading = () => {
 
 export const calculateUptime = (timeseries, regions) => {
   const timeseriesByDay = groupTimeseriesByDay(timeseries, regions);
-  const timeSeriesLast30Days = timeseriesByDay
-    .slice(-30, timeseriesByDay.length - 1)
+  const latestDay = timeseriesByDay[timeseriesByDay.length - 1];
+  const completedTimeseriesByDay =
+    latestDay && dayjs(latestDay.timestamp).utc().isSame(dayjs().utc(), "day")
+      ? timeseriesByDay.slice(0, -1)
+      : timeseriesByDay;
+  const timeSeriesLast30Days = completedTimeseriesByDay
+    .slice(-30)
     .filter((item) => item.missingDataPoint === false);
   const minutesPerDay = 1440.0;
 

--- a/components/UptimeMonitor/UptimeMonitor.test.js
+++ b/components/UptimeMonitor/UptimeMonitor.test.js
@@ -111,18 +111,36 @@ describe("calculateUptime", () => {
     ]);
   });
 
-  test("excludes the current in-progress day from the uptime percentage", () => {
+  test("includes the current in-progress day using elapsed minutes", () => {
     MockDate.set("2026-05-27T12:00:00Z");
 
     const uptime = calculateUptime(
       [
         {
-          timestamp: "2026-05-26T12:00:00Z",
-          values: { europe: 0 },
-        },
-        {
           timestamp: "2026-05-27T12:00:00Z",
           values: { europe: 14 },
+        },
+      ],
+      ["europe"]
+    );
+
+    expect(uptime).toEqual([
+      {
+        region: "europe",
+        minutes: 14,
+        percentage: 98.06,
+      },
+    ]);
+  });
+
+  test("keeps the current day at 100 percent when there is no downtime", () => {
+    MockDate.set("2026-05-27T12:00:00Z");
+
+    const uptime = calculateUptime(
+      [
+        {
+          timestamp: "2026-05-27T12:00:00Z",
+          values: { europe: 0 },
         },
       ],
       ["europe"]
@@ -135,5 +153,21 @@ describe("calculateUptime", () => {
         percentage: 100,
       },
     ]);
+  });
+
+  test("excludes the current day when no uptime has elapsed yet", () => {
+    MockDate.set("2026-05-27T00:00:00Z");
+
+    const uptime = calculateUptime(
+      [
+        {
+          timestamp: "2026-05-27T00:00:00Z",
+          values: { europe: 0 },
+        },
+      ],
+      ["europe"]
+    );
+
+    expect(uptime).toEqual([]);
   });
 });

--- a/components/UptimeMonitor/UptimeMonitor.test.js
+++ b/components/UptimeMonitor/UptimeMonitor.test.js
@@ -1,8 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import MockDate from "mockdate";
 
 import UptimeMonitor, {
   UptimeMonitorLoading,
   averageDowntimeOverRegions,
+  calculateUptime,
 } from "./UptimeMonitor";
 import statusPageMock from "../../mocks/status_pages/appsignal.json";
 
@@ -75,5 +77,63 @@ describe("UptimeMonitorLoading", () => {
     test("returns 0 if no regions are present", () => {
       expect(averageDowntimeOverRegions([])).toEqual(0);
     });
+  });
+});
+
+describe("calculateUptime", () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  test("includes the latest completed day in the uptime percentage", () => {
+    MockDate.set("2026-05-27T12:00:00Z");
+
+    const uptime = calculateUptime(
+      [
+        {
+          timestamp: "2026-05-25T12:00:00Z",
+          values: { europe: 0 },
+        },
+        {
+          timestamp: "2026-05-26T12:00:00Z",
+          values: { europe: 14 },
+        },
+      ],
+      ["europe"]
+    );
+
+    expect(uptime).toEqual([
+      {
+        region: "europe",
+        minutes: 14,
+        percentage: 99.52,
+      },
+    ]);
+  });
+
+  test("excludes the current in-progress day from the uptime percentage", () => {
+    MockDate.set("2026-05-27T12:00:00Z");
+
+    const uptime = calculateUptime(
+      [
+        {
+          timestamp: "2026-05-26T12:00:00Z",
+          values: { europe: 0 },
+        },
+        {
+          timestamp: "2026-05-27T12:00:00Z",
+          values: { europe: 14 },
+        },
+      ],
+      ["europe"]
+    );
+
+    expect(uptime).toEqual([
+      {
+        region: "europe",
+        minutes: 0,
+        percentage: 100,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
Fix uptime percentage calculation around the most recent day.
Previously, the calculation always dropped the newest grouped day from the 30-day window. That caused outages on the latest completed day to be ignored until newer ticks arrived later, which could temporarily show `100%` uptime even after a real outage.
This change updates the calculation so that:
- the latest completed day is always included
- the current UTC day is included when it has ticks
- the current day uses only elapsed minutes since midnight UTC as its denominator
- a latest day with no usable elapsed uptime is excluded